### PR TITLE
Fix some links in the references

### DIFF
--- a/vldb-best/main.bib
+++ b/vldb-best/main.bib
@@ -1993,7 +1993,7 @@
 @Misc{tr,
   author =       {Mihai Budiu and Frank McSherry and Leonid Ryzhyk and Val Tannen},
   title =        {{DBSP}: A Language for Expressing Incremental View Maintenance for Rich Query Languages},
-  howpublished = {\url{https://github.com/feldera/feldera/blob/main/doc/spec.pdf}},
+  howpublished = {\url{https://www.feldera.com/spec.pdf}},
   year =         {2022},
   month =        {December}
 }
@@ -2878,6 +2878,7 @@
     title = {{DBSP} formalization},
     author = {Tej Chajed},
     url = "https://github.com/tchajed/dbsp-theory",
+    howpublished = "\url{https://github.com/tchajed/dbsp-theory}",
     year = 2022,
     month = dec,
 }
@@ -2995,7 +2996,7 @@
 @misc{dbsp-crate,
     title = {{DBSP} {Rust} Crate},
     author = {{Feldera Inc.}},
-    howpublished = {\url{https://crates.com/crates/dbsp}},
+    howpublished = {\url{https://crates.io/crates/dbsp}},
     note = {Retrieved March 2024},
 }
 


### PR DESCRIPTION
I used the link https://www.feldera.com/spec.pdf since that seemed preferable to linking to the feldera/papers repo directly, but let me know if you expect the GitHub link to be more stable.